### PR TITLE
Update constants.dart

### DIFF
--- a/packages/tinkoff_acquiring/lib/src/constants.dart
+++ b/packages/tinkoff_acquiring/lib/src/constants.dart
@@ -145,7 +145,7 @@ abstract class JsonKeys {
 }
 
 abstract class NetworkSettings {
-  static const String domainDebug = 'rest-api-test.tinkoff.ru';
+  static const String domainDebug = 'securepay.tinkoff.ru';
   static const String domainRelease = 'securepay.tinkoff.ru';
   static const String apiPath = '/';
   static const String apiVersion2 = 'v2';


### PR DESCRIPTION
Согласно последней документации, домен для дебага такой же, как и для релизной версии.

<img width="1109" alt="Снимок экрана 2024-07-09 в 07 33 36" src="https://github.com/MadBrains/Tinkoff-Acquiring-SDK-Flutter/assets/23329828/7bec597b-9eab-457d-a03f-759cfbf23f54">

